### PR TITLE
Separated default key bindings and Mac-specific ones

### DIFF
--- a/Key Bindings (Mac).json
+++ b/Key Bindings (Mac).json
@@ -1,13 +1,19 @@
 [
     {
         "keys": [
-            "Ctrl+F"
+            "Cmd+F"
         ],
         "command": "search_files_in_this_folder"
     },
     {
         "keys": [
-            "Ctrl+Shift+F"
+            "Cmd+E"
+        ],
+        "command": "search_files_in_this_folder"
+    },
+    {
+        "keys": [
+            "Cmd+Shift+F"
         ],
         "command": "search_files_in_sub_folders"
     }

--- a/Key Bindings (Mac).json
+++ b/Key Bindings (Mac).json
@@ -1,20 +1,5 @@
 [
-    {
-        "keys": [
-            "Cmd+F"
-        ],
-        "command": "search_files_in_this_folder"
-    },
-    {
-        "keys": [
-            "Cmd+E"
-        ],
-        "command": "search_files_in_this_folder"
-    },
-    {
-        "keys": [
-            "Cmd+Shift+F"
-        ],
-        "command": "search_files_in_sub_folders"
-    }
+    { "keys": [ "Cmd+F" ], "command": "search_files_in_this_folder" },
+    { "keys": [ "Cmd+E" ], "command": "search_files_in_this_folder" },
+    { "keys": [ "Cmd+Shift+F" ], "command": "search_files_in_sub_folders" }
 ]

--- a/Key Bindings.json
+++ b/Key Bindings.json
@@ -1,14 +1,4 @@
 [
-    {
-        "keys": [
-            "Ctrl+F"
-        ],
-        "command": "search_files_in_this_folder"
-    },
-    {
-        "keys": [
-            "Ctrl+Shift+F"
-        ],
-        "command": "search_files_in_sub_folders"
-    }
+    { "keys": [ "Ctrl+F" ], "command": "search_files_in_this_folder" },
+    { "keys": [ "Ctrl+Shift+F" ], "command": "search_files_in_sub_folders" }
 ]


### PR DESCRIPTION
#1 

Made `Ctrl+*` bindings default (for Windows and Linux) and created separate file for Mac equivalent to the original key map file.